### PR TITLE
Use pnpm instead of yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "vite",
     "build": "rimraf ./dist/* && tsc && vite build",
-    "build:package": "yarn build && yarn package",
+    "build:package": "pnpm build && pnpm package",
     "package": "rimraf ./build/* && node ./bin/package.js",
     "serve": "vite preview",
     "lint": "eslint --max-warnings 0 --ext ts,tsx ./src",


### PR DESCRIPTION
All other apps use `pnpm` so we should follow suit and not use `yarn`