### PR TITLE
[Feat] Show Release Notes In Product (SC-187399)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^17.0.2",
     "react-resize-observer": "^1.1.1",
     "rss-to-json": "^2.1.1",
+    "semver": "^7.7.1",
     "simplebar": "^6.3.0",
     "tippy.js": "^6.3.7",
     "tough-cookie": "4.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       rss-to-json:
         specifier: ^2.1.1
         version: 2.1.1
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.1
       simplebar:
         specifier: ^6.3.0
         version: 6.3.0

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,11 +3,13 @@ import { Feed } from "./types";
 
 const AGENT_NEWS_RSS_URL = "https://support.deskpro.com/en/news/product-agent.rss";
 const ADMIN_NEWS_RSS_URL = "https://support.deskpro.com/en/news/product-admin.rss";
+const RELEASE_NOTES_RSS_URL = "https://support.deskpro.com/en/news/deskpro-releases.rss";
 
-export const fetchAdminFeed = async () => fetchFeed(ADMIN_NEWS_RSS_URL);
-export const fetchAgentFeed = async () => fetchFeed(AGENT_NEWS_RSS_URL);
+export const fetchAdminFeed = async () => fetchFeed(ADMIN_NEWS_RSS_URL, "product-admin");
+export const fetchAgentFeed = async () => fetchFeed(AGENT_NEWS_RSS_URL, "product-agent");
+export const fetchReleaseFeed = async () => fetchFeed(RELEASE_NOTES_RSS_URL, "release");
 
-const fetchFeed = async (url: string): Promise<Feed|null> => {
+const fetchFeed = async (url: string, type: Feed["type"]): Promise<Feed | null> => {
     try {
         const feed = await parse(url);
 
@@ -15,7 +17,10 @@ const fetchFeed = async (url: string): Promise<Feed|null> => {
             return null;
         }
 
-        return feed;
+        return {
+            ...feed,
+            type
+        }
     } catch (e) {
         console.error(e);
     }

--- a/src/components/NewsFeedCard/NewsFeedCard.css
+++ b/src/components/NewsFeedCard/NewsFeedCard.css
@@ -1,0 +1,98 @@
+.news-feed-card{
+    position: relative;
+    text-decoration: none;
+    color: var(--dark-40);
+    width: 100%;
+    overflow: hidden;
+    border-radius: 12px;
+    box-sizing: border-box;
+    transition: 0.3s;
+    border: 2px solid var(--grey-20);
+}
+
+.news-feed-card * {
+    color: inherit;
+}
+
+.news-feed-card:hover {
+    border-color:  var(--grey-40) !important;
+}
+
+.news-feed-card-date{
+    position: absolute;
+    background-color: white;
+    box-shadow: 1.0px 1.9px 1.9px rgba(0, 0, 0, 0.47);
+    padding: 10px;
+    text-align: center;
+    right: 12px;
+    border-radius: 0px 0px 10px 10px;
+}
+
+.news-feed-card-cover{
+    width: 100%;
+}
+
+.news-feed-card-cover img{
+    width: 100%;
+    height: 140px;
+    /* aspect-ratio: 1/2; */
+    object-position: center;
+    object-fit: cover;
+}
+
+.news-feed-card-body{
+    padding: 12px;
+    font-size: 11px;
+    position: relative;
+    line-height: 16px;
+
+}
+
+.news-feed-card-body-content {
+    max-height: 170px; /* Adjust this value as needed */
+    overflow: hidden;
+    position: relative;
+}
+
+.news-feed-card-body-content a,
+.news-feed-card-body-content button,
+.news-feed-card-body-content [tabindex] {
+    pointer-events: none;
+}
+
+.news-feed-card-body-content::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 100px; /* Height of the gradient */
+    background: linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
+    pointer-events: none; /* Allows clicking through the gradient */
+}
+
+.news-feed-card-body h1,
+.news-feed-card-body h2,
+.news-feed-card-body h3,
+.news-feed-card-body h4 {
+    font-family: "Inter", sans-serif;
+    font-weight: 600;
+}
+
+.news-feed-card-body h1 {
+    font-size: 18px;
+}
+
+.news-feed-card-body h2 {
+    font-size: 16px;
+}
+
+.news-feed-card-body h3,
+.news-feed-card-body h4 {
+    font-size: 14px;
+}
+
+.news-feed-card-body a {
+    color: #7A56DE;
+    text-decoration: none;
+}

--- a/src/components/NewsFeedCard/NewsFeedCard.tsx
+++ b/src/components/NewsFeedCard/NewsFeedCard.tsx
@@ -1,0 +1,82 @@
+import { H0, P4, } from "@deskpro/deskpro-ui";
+import { FeedItem } from "../../types";
+import "./NewsFeedCard.css";
+import { useDeskproAppTheme } from "@deskpro/app-sdk";
+import { removeContentImages } from "../../utils";
+import { useEffect, useRef } from "react";
+
+
+interface NewsFeedCardProps {
+    newsMeta: FeedItem;
+    shownItems: number;
+    setShownItems: (shownItems: number) => void;
+    isLastItem: boolean;
+}
+
+export function NewsFeedCard(props: Readonly<NewsFeedCardProps>) {
+
+    const { newsMeta, shownItems, setShownItems, isLastItem } = props
+    const { theme } = useDeskproAppTheme()
+    const cardRef = useRef<HTMLAnchorElement>(null)
+
+    const publishedDate = new Date(newsMeta.published)
+    const coverSrc = newsMeta.enclosures?.[0]?.url
+
+    const monthDay = publishedDate.toLocaleString('en-US', { month: 'short', day: '2-digit' }).toUpperCase()
+    const year = publishedDate.getFullYear();
+
+    useEffect(() => {
+        if (!isLastItem || !cardRef.current) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setShownItems(shownItems + 5);
+                }
+            },
+            {
+                root: null,
+                rootMargin: "0px",
+                threshold: 0.5,
+            }
+        );
+
+        observer.observe(cardRef.current);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [isLastItem, shownItems, setShownItems])
+
+
+
+    return (
+        <a ref={cardRef} href={newsMeta.link} target="_blank" className="news-feed-card"
+            style={{
+                '--grey-40': theme.colors.grey40,
+                '--dark-40': theme.colors.grey100,
+                '--grey-20': theme.colors.grey20,
+            } as React.CSSProperties & { [key: string]: string }}
+        >
+            <div className="news-feed-card-date"><P4>{monthDay}</P4> <P4>{year}</P4></div>
+            <div className="news-feed-card-cover">
+                <img src={coverSrc} loading="lazy" />
+            </div>
+
+            <div className="news-feed-card-body">
+                <H0>{newsMeta?.title}</H0>
+
+                <div
+                    className="news-feed-card-body-content"
+                    tabIndex={-1}
+                    dangerouslySetInnerHTML={{
+                        __html: removeContentImages(newsMeta?.description ?? ""),
+                    }}
+                />
+            </div>
+
+        </a>
+    )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,14 @@ export type Feed = {
     image: string;
     category: string[];
     items: FeedItem[];
+    type: "product-agent" | "product-admin" | "release";
 };
+
+type Enclosure ={
+    url? :string,
+    length?: string,
+    type?: string
+}
 
 export type FeedItem = {
     title: string;
@@ -13,6 +20,8 @@ export type FeedItem = {
     link: string;
     published: number;
     created: number;
+    enclosures?: Enclosure[]
+    type: Feed["type"]
 };
 
 export type ParentFeedPayload = {


### PR DESCRIPTION
## Evidence

### When there's a newer release available.

<img width="270" alt="image" src="https://github.com/user-attachments/assets/21b42e88-c88c-4397-8ed4-267965f9569b" />

### When the user has the latest version/ no release notes are available for newer versions.

<img width="270" alt="image" src="https://github.com/user-attachments/assets/c8a1ef39-3986-472b-b7c4-088b76d00a40" />
