### PR TITLE
Remove unusued axios dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@sentry/vite-plugin": "^3.5.0",
     "@types/he": "^1.2.3",
     "@types/lodash": "^4.17.20",
-    "axios": "1.7.4",
     "decode-uri-component": "0.2.1",
     "flatpickr": "^4.6.13",
     "he": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
-      axios:
-        specifier: 1.7.4
-        version: 1.7.4
       decode-uri-component:
         specifier: 0.2.1
         version: 0.2.1


### PR DESCRIPTION
This pull request removes the `axios` dependency from the project. The most important changes include the removal of `axios` from the `package.json` file and its corresponding entry in the `pnpm-lock.yaml` file.

Dependency removal:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23): Removed the `axios` dependency (version `1.7.4`).
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-L31): Removed the `axios` entry from the lock file, including its specifier and version.